### PR TITLE
Enforces role-based access control for pages

### DIFF
--- a/src/pages/NoRole.jsx
+++ b/src/pages/NoRole.jsx
@@ -1,14 +1,66 @@
+import { useEffect, useState } from "react";
+import api from "../utils/api";
+
 const NoRole = () => {
-    return (
-        <div className="flex flex-col items-center justify-center h-screen bg-gray-100">
-            <h1 className="text-4xl font-bold text-gray-800 mb-4">No Role Assigned</h1>
-            <p className="text-lg text-gray-600">You do not have a role assigned to your account.</p>
-            <p className="text-lg text-gray-600">Please contact your administrator for assistance.</p>
-            <a href="/login" className="mt-4 text-blue-600 hover:underline">
-            Go to login
-            </a>
-        </div >
-    );
-}
+	const [userRole, setUserRole] = useState(null);
+	const [loading, setLoading] = useState(true);
+
+	useEffect(() => {
+		const fetchUserRole = async () => {
+			try {
+				const { data } = await api.get("/api/me");
+				setUserRole(data.role);
+			} catch (error) {
+				console.error("Error fetching user role:", error);
+			} finally {
+				setLoading(false);
+			}
+		};
+
+		fetchUserRole();
+	}, []);
+
+	return (
+		<div className="flex flex-col items-center justify-center h-screen bg-gray-100 p-4">
+			<div className="bg-white rounded-lg shadow-md p-8 max-w-md w-full text-center">
+				<h1 className="text-3xl font-bold text-red-600 mb-4">
+					Không có quyền truy cập
+				</h1>
+
+				{loading ? (
+					<p className="text-gray-600 mb-4">Đang tải thông tin...</p>
+				) : (
+					<>
+						<p className="text-lg text-gray-700 mb-2">
+							Tài khoản của bạn có vai trò:{" "}
+							<span className="font-semibold">
+								{userRole || "Chưa xác định"}
+							</span>
+						</p>
+						<p className="text-gray-600 mb-6">
+							Bạn không có quyền truy cập vào trang này. Vui lòng quay lại trang
+							phù hợp với vai trò của bạn.
+						</p>
+					</>
+				)}
+
+				{userRole && (
+					<a
+						href={`/${userRole.toLowerCase()}`}
+						className="inline-block bg-blue-500 hover:bg-blue-600 text-white font-medium py-2 px-6 rounded transition-colors"
+					>
+						Đi đến trang {userRole}
+					</a>
+				)}
+
+				<div className="mt-4">
+					<a href="/login" className="text-blue-500 hover:underline">
+						Đăng nhập lại
+					</a>
+				</div>
+			</div>
+		</div>
+	);
+};
 
 export default NoRole;

--- a/src/utils/privaterouter.jsx
+++ b/src/utils/privaterouter.jsx
@@ -1,19 +1,59 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Navigate } from "react-router-dom";
 import { supabase } from "../utils/supabase";
-const PrivateRouter = ({children}) => {
+import api from "../utils/api";
+
+const PrivateRouter = ({ children, requiredRole }) => {
+    const [loading, setLoading] = useState(true);
+    const [user, setUser] = useState(null);
+
+    useEffect(() => {
+        const checkUserRole = async () => {
+            try {
+                const projectRef = supabase.supabaseUrl.split("https://")[1].split(".")[0];
+                const session = localStorage.getItem(`sb-${projectRef}-auth-token`);
+                const tempSession = sessionStorage.getItem("tempSession");
+
+                if (!session && !tempSession) {
+                    setLoading(false);
+                    return;
+                }
+
+                const { data } = await api.get("/me");
+                setUser(data);
+                setLoading(false);
+            } catch (error) {
+                console.error("Error checking user role:", error);
+                setLoading(false);
+            }
+        };
+
+        checkUserRole();
+    }, []);
+
     if (typeof window !== "undefined" && window.location.hash.includes("type=recovery")) {
-        return <Navigate to="/update-password" replace/>
+        return <Navigate to="/update-password" replace />;
     }
+
     const projectRef = supabase.supabaseUrl.split("https://")[1].split(".")[0];
     const session = localStorage.getItem(`sb-${projectRef}-auth-token`);
     const tempSession = sessionStorage.getItem("tempSession");
 
-    // Kiểm tra cả localStorage và sessionStorage
     if (!session && !tempSession) {
-        return <Navigate to="/login" replace/>
+        return <Navigate to="/login" replace />;
     }
+
+    if (loading) {
+        return <div className="flex items-center justify-center h-screen">
+            <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-blue-500"></div>
+        </div>;
+    }
+
+    if (requiredRole && user && user.role !== requiredRole) {
+        return <Navigate to="/no-role" replace />;
+    }
+
     return children;
-}
+};
 
 export default PrivateRouter;

--- a/src/utils/router.jsx
+++ b/src/utils/router.jsx
@@ -23,8 +23,8 @@ const router = createBrowserRouter([
   { path: "/signup", element: <Signup /> },
   { path: "/forgot-password", element: <ForgotPassword /> },
   { path: "/update-password", element: <UpdatePassword /> },
-  { path: "/nurse", element: <PrivateRouter><NurseDashboard /></PrivateRouter> },
-  { path: "/parent", element: <PrivateRouter><ParentDashboard /></PrivateRouter>, children: [
+  { path: "/nurse", element: <PrivateRouter requiredRole="NURSE"><NurseDashboard /></PrivateRouter> },
+  { path: "/parent", element: <PrivateRouter requiredRole="PARENT"><ParentDashboard /></PrivateRouter>, children: [
     { index: true, element: <StudentInfo /> },
     { path: "info", element: <StudentInfo /> },
     { path: "medical-record", element: <MedicalRecord /> },
@@ -32,8 +32,8 @@ const router = createBrowserRouter([
     { path: "health-check", element: <HealthCheck /> },
     { path: "prescription", element: <Prescription /> },
   ]},
-  { path: "/manager", element: <PrivateRouter><ManagerDashboard /></PrivateRouter> },
-  { path: "/admin", element: <PrivateRouter><AdminDashboard /></PrivateRouter> },
+  { path: "/manager", element: <PrivateRouter requiredRole="MANAGER"><ManagerDashboard /></PrivateRouter> },
+  { path: "/admin", element: <PrivateRouter requiredRole="ADMIN"><AdminDashboard /></PrivateRouter> },
   { path: "/no-role", element: <NoRole /> },
   { path: "/auth/callback", element: <AuthCallback/> },
 ]);


### PR DESCRIPTION
Implements role-based access control to restrict access to pages based on the user's role.

- Adds a `PrivateRouter` component that checks the user's role against a required role.
- Redirects users to a "no role" page if they lack the necessary permissions.
- Fetches user role information from the `/me` endpoint.
- Updates the `NoRole` page to display the user's current role and a link to the appropriate page if a role is assigned.